### PR TITLE
Upgrade dependencies version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "homepage": "https://github.com/pling/bunyan-aws#readme",
   "engine": "node >= 4.5.0",
   "dependencies": {
-    "async": "^2.0.1",
-    "aws-sdk": "2.6.x"
+    "async": "^3.1.0",
+    "aws-sdk": "^2.606.0"
   },
   "peerDependencies": {
     "bunyan": ">= 1.8.1"


### PR DESCRIPTION
These library versions are too old and contain vulnerabilities. Please kindly accept the change and release the new version so we can avoid seeing vulnerabilities from `npm audit`.