### PR TITLE
Handle InvalidSequenceTokenException

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,6 +151,9 @@ module.exports = class CloudWatchStream extends EventEmitter {
                 if (error) {
                     if (error.retryable && attempts++ < 5) {
                         setTimeout(postLogEvents, 100);
+                    } else if (error.code === 'InvalidSequenceTokenException') {
+                        delete that._sequenceToken;
+                        that._getSequenceToken(postLogEvents)
                     } else {
                         callback(error);
                     }


### PR DESCRIPTION
In some rare scenarios, the _sequenceToken may get out of date. When that happen, AWS returns InvalidSequenceTokenException. This is not retry-able. Instead, we need to obtain the sequenceToken from AWS again.

According to https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CloudWatchLogs.html#putLogEvents-property, `expectedSequenceToken` is supposed to be in the error object, but actually testing it shows that it is not there, so I need to call `_getSequenceToken` to obtain the new token.

Similar approach is taken in bunyan-cloudwatch:
https://github.com/mirkokiefer/bunyan-cloudwatch/blob/master/index.js#L59