### PR TITLE
Handle all non-retriable errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,8 @@ module.exports = class CloudWatchStream extends EventEmitter {
                 if (error) {
                     if (error.retryable && attempts++ < 5) {
                         setTimeout(postLogEvents, 100);
-                    } else if (error.code === 'InvalidSequenceTokenException') {
+                    } else if (error.code === 'InvalidSequenceTokenException'
+                            || error.code === 'DataAlreadyAcceptedException') {
                         delete that._sequenceToken;
                         that._getSequenceToken(postLogEvents)
                     } else {

--- a/index.js
+++ b/index.js
@@ -149,12 +149,13 @@ module.exports = class CloudWatchStream extends EventEmitter {
             that._cloudWatchLogs.putLogEvents(params, function (error, data) {
                 that._posting = false;
                 if (error) {
-                    if (error.retryable && attempts++ < 5) {
-                        setTimeout(postLogEvents, 100);
-                    } else if (error.code === 'InvalidSequenceTokenException'
-                            || error.code === 'DataAlreadyAcceptedException') {
-                        delete that._sequenceToken;
-                        that._getSequenceToken(postLogEvents)
+                    if (attempts++ < 5) {
+                        if (error.retryable) {
+                            setTimeout(postLogEvents, 100);
+                        } else {
+                            delete that._sequenceToken;
+                            that._getSequenceToken(postLogEvents);
+                        }
                     } else {
                         callback(error);
                     }


### PR DESCRIPTION
We recently got back some `DataAlreadyAcceptedException`, which seems to be similar issue as `InvalidSequenceTokenException`. To generalize this, will try to get a new sequenceToken up to 5 times before giving up even for non-retriable error.