### PR TITLE
Handle ResourceAlreadyExistsException

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,9 +120,12 @@ module.exports = class CloudWatchStream extends EventEmitter {
         this._cloudWatchLogs.createLogStream(params, function(err, data) {
             if (data) {
                 that._sequenceToken = null;
+                callback(null, data);
+            } else if (err.code === 'ResourceAlreadyExistsException') {
+                that._getSequenceToken(callback);
+            } else {
+                callback(err, data);
             }
-
-            callback(err, data);
         });
     }
 


### PR DESCRIPTION
In some very rare situations, we are seeing some race condition where createLogStream failed with 'ResourceAlreadyExistsException'. This should fix that race condition.